### PR TITLE
Fix for properly work with defined 'list_filter' option

### DIFF
--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.util import unquote
+from django.contrib.admin.views.main import ChangeList
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
@@ -8,9 +9,11 @@ from functools import update_wrapper
 from django.utils.html import strip_spaces_between_tags as short
 from django.utils.translation import ugettext_lazy as _
 
+
 class OrderedModelAdmin(admin.ModelAdmin):
     def get_urls(self):
         from django.conf.urls import patterns, url
+
         def wrap(view):
             def wrapper(*args, **kwargs):
                 return self.admin_site.admin_view(view)(*args, **kwargs)
@@ -24,30 +27,50 @@ class OrderedModelAdmin(admin.ModelAdmin):
                 wrap(self.move_view),
                 name='%s_%s_move_down' % info),
         ) + super(OrderedModelAdmin, self).get_urls()
-        
+
+    def _get_changelist(self, request):
+        list_display = self.get_list_display(request)
+        list_display_links = self.get_list_display_links(request, list_display)
+
+        cl = ChangeList(request, self.model, list_display,
+            list_display_links, self.list_filter, self.date_hierarchy,
+            self.search_fields, self.list_select_related,
+            self.list_per_page, self.list_max_show_all, self.list_editable,
+            self)
+
+        return cl
+
+    request_query_string = ''
+
+    def changelist_view(self, request, extra_context=None):
+        cl = self._get_changelist(request)
+        self.request_query_string = cl.get_query_string()
+        return super(OrderedModelAdmin, self).changelist_view(request, extra_context)
+
     def move_view(self, request, object_id, direction):
+        cl = self._get_changelist(request)
+        qs = cl.get_query_set(request)
+
         obj = get_object_or_404(self.model, pk=unquote(object_id))
-        if direction == 'up':
-            obj.move_up()
-        else:
-            obj.move_down()
-        return HttpResponseRedirect('../../')
-    
-    link_html = short("""
-        <a href="../../%(app_label)s/%(module_name)s/%(object_id)s/move-up/">
-            <img src="%(STATIC_URL)sordered_model/arrow-up.gif" alt="Move up" />
-        </a>
-        <a href="../../%(app_label)s/%(module_name)s/%(object_id)s/move-down/">
-            <img src="%(STATIC_URL)sordered_model/arrow-down.gif" alt="Move down" />
-        </a>""")
-    
+        obj.move(direction, qs)
+
+        return HttpResponseRedirect('../../%s' % self.request_query_string)
+
     def move_up_down_links(self, obj):
-        return self.link_html % {
+        link_html = short("""
+            <a href="../../%(app_label)s/%(module_name)s/%(object_id)s/move-up/%(query_string)s">
+                <img src="%(STATIC_URL)sordered_model/arrow-up.gif" alt="Move up" />
+            </a>
+            <a href="../../%(app_label)s/%(module_name)s/%(object_id)s/move-down/%(query_string)s">
+                <img src="%(STATIC_URL)sordered_model/arrow-down.gif" alt="Move down" />
+            </a>""")
+
+        return link_html % {
             'app_label': self.model._meta.app_label,
             'module_name': self.model._meta.module_name,
             'object_id': obj.id,
             'STATIC_URL': settings.STATIC_URL,
+            'query_string': self.request_query_string
         }
     move_up_down_links.allow_tags = True
     move_up_down_links.short_description = _(u'Move')
-    

--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -2,18 +2,19 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from django.db import models
 
+
 class OrderedModel(models.Model):
     """
     An abstract model that allows objects to be ordered relative to each other.
     Provides an ``order`` field.
     """
-    
+
     order = models.PositiveIntegerField(editable=False)
-    
+
     class Meta:
         abstract = True
         ordering = ('order',)
-    
+
     def save(self, *args, **kwargs):
         if not self.id:
             qs = self.__class__.objects.order_by('-order')
@@ -22,9 +23,11 @@ class OrderedModel(models.Model):
             except IndexError:
                 self.order = 0
         super(OrderedModel, self).save(*args, **kwargs)
-    
-    def _move(self, up):
-        qs = self.__class__._default_manager
+
+    def _move(self, up, qs=None):
+        if qs is None:
+            qs = self.__class__._default_manager
+
         if up:
             qs = qs.order_by('-order').filter(order__lt=self.order)
         else:
@@ -37,13 +40,16 @@ class OrderedModel(models.Model):
         self.order, replacement.order = replacement.order, self.order
         self.save()
         replacement.save()
-    
+
+    def move(self, direction, qs=None):
+        self._move(direction == 'up', qs)
+
     def move_down(self):
         """
         Move this object down one position.
         """
         return self._move(up=False)
-    
+
     def move_up(self):
         """
         Move this object up one position.


### PR DESCRIPTION
Current realisation move_view ignores the state of model, e.g. if we try to move items with active 'list_filter' option, it will be reset.
