### PR TITLE
Make "order" field an index and use Max aggregate to find next order value.

### DIFF
--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -1,6 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from django.db import models
+from django.db.models import Max
 
 
 class OrderedModel(models.Model):
@@ -17,11 +18,8 @@ class OrderedModel(models.Model):
 
     def save(self, *args, **kwargs):
         if not self.id:
-            qs = self.__class__.objects.order_by('-order')
-            try:
-                self.order = qs[0].order + 1
-            except IndexError:
-                self.order = 0
+            c = self.__class__.objects.all().aggregate(Max('order')).get('order__max')
+            self.order = c and c + 1 or 0
         super(OrderedModel, self).save(*args, **kwargs)
 
     def _move(self, up, qs=None):


### PR DESCRIPTION
The "order" field should be a database index for performance reasons. Using the MAX(order) SQL aggregate should also improve performance for larger datasets.
