### PR TITLE
Make sure second order is correctly generated.

### DIFF
--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -21,7 +21,7 @@ class OrderedModel(models.Model):
     def save(self, *args, **kwargs):
         if not self.id:
             c = self.__class__.objects.all().aggregate(Max('order')).get('order__max')
-            self.order = c and c + 1 or 0
+            self.order = 0 if c is None else c + 1
         super(OrderedModel, self).save(*args, **kwargs)
 
     def _move(self, up, qs=None):

--- a/ordered_model/tests/tests.py
+++ b/ordered_model/tests/tests.py
@@ -1,6 +1,15 @@
 from django.test import TestCase
 from ordered_model.tests.models import Item
 
+
+class OrderGenerationTests(TestCase):
+    def test_second_order_generation(self):
+        first_item = Item.objects.create()
+        self.assertEqual(first_item.order, 0)
+        second_item = Item.objects.create()
+        self.assertEqual(second_item.order, 1)
+
+
 class ModelTestCase(TestCase):
     fixtures = ['test_items.json']
 


### PR DESCRIPTION
Since the first object is created with an order of `0` and `bool(0)` evaluates
to `False` we must make sure to differentiate between `0` and `None` when
generating the second object order.
