### PR TITLE
Uses a Mixin rather than a class two allow multiple inheritance from oth...

### DIFF
--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -6,17 +6,6 @@ from django.db.models import Max, Min, F
 from django.utils.translation import ugettext as _
 
 
-class OrderedModel(models.Model, OrderedModelMixin):
-    """
-    An abstract model that allows objects to be ordered relative to each other.
-    Provides an ``order`` field.
-    """
-    
-    class Meta:
-        abstract = True
-        ordering = ('order',)
-
-
 class OrderedModelMixin(object):
     """
     A model mixin that allows objects to be ordered relative to each other.
@@ -154,3 +143,14 @@ class OrderedModelMixin(object):
         """
         o = self.__class__.objects.all().aggregate(Max('order')).get('order__max')
         self.to(o)
+
+
+class OrderedModel(models.Model, OrderedModelMixin):
+    """
+    An abstract model that allows objects to be ordered relative to each other.
+    Provides an ``order`` field.
+    """
+    
+    class Meta:
+        abstract = True
+        ordering = ('order',)


### PR DESCRIPTION
...er classes than django.db.models.Model

Uses a Mixin rather than a class two allow multiple inheritance from other classes than django.db.models.Model.

This abstraction of the new behavior and the django model comes handy if you want to add the ordered-model behavoir to a 3rd party model.
