### PR TITLE
Allow using custom primary keys on models.

### DIFF
--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -36,7 +36,7 @@ class OrderedModel(models.Model):
         return qs
 
     def save(self, *args, **kwargs):
-        if not self.id:
+        if self.order is None:
             c = self.get_ordering_queryset().aggregate(Max('order')).get('order__max')
             self.order = 0 if c is None else c + 1
         super(OrderedModel, self).save(*args, **kwargs)

--- a/ordered_model/tests/models.py
+++ b/ordered_model/tests/models.py
@@ -19,3 +19,8 @@ class Answer(OrderedModel):
 
     def __unicode__(self):
         return u"Answer #%d of question #%d" % (self.order, self.question_id)
+
+
+class CustomItem(OrderedModel):
+    id = models.CharField(max_length=100, primary_key=True)
+    name = models.CharField(max_length=100)

--- a/ordered_model/tests/tests.py
+++ b/ordered_model/tests/tests.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
-from ordered_model.tests.models import Answer, Item, Question
-
+from ordered_model.tests.models import Answer, Item, Question, CustomItem
+import uuid
 
 class OrderGenerationTests(TestCase):
     def test_second_order_generation(self):
@@ -170,3 +170,21 @@ class OrderWithRespectToTests(TestCase):
             (self.q1_a1.pk, 0), (self.q1_a2.pk, 1),
             (self.q2_a2.pk, 0), (self.q2_a1.pk, 1)
         ])
+
+
+class CustomPKTest(TestCase):
+    def setUp(self):
+        self.item1 = CustomItem.objects.create(id=str(uuid.uuid4()), name='1')
+        self.item2 = CustomItem.objects.create(id=str(uuid.uuid4()), name='2')
+        self.item3 = CustomItem.objects.create(id=str(uuid.uuid4()), name='3')
+        self.item4 = CustomItem.objects.create(id=str(uuid.uuid4()), name='4')
+
+    def test_saved_order(self):
+        self.assertSequenceEqual(
+            CustomItem.objects.values_list('pk', 'order'), [
+                (self.item1.pk, 0),
+                (self.item2.pk, 1),
+                (self.item3.pk, 2),
+                (self.item4.pk, 3)
+            ]
+        )


### PR DESCRIPTION
This issue is related to https://github.com/bfirsh/django-ordered-model/issues/29.

Basically, I'm using https://github.com/dcramer/django-uuidfield as primary keys for my models and OrderedModel wouldn't set the order properly for those models. The reason for that is that OrderedModel will set the order only when the saved model has no id set and UUIDField sets the id before saving the model.

Instead of depending on model id, the code will now check if the order field isn't set. 
