### PR TITLE
Fixes models not keeping order in cascaded deletes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Change log
 Unreleased
 ----------
 
+- Cascaded deletes of `OrderedModel` instances now handled using signals (#182)
+
 3.7 - 2023-03-03
 ----------
 

--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ Test suite
 To run the tests against your current environment, use:
 
 ```bash
+$ pip install djangorestframework
 $ django-admin test --pythonpath=. --settings=tests.settings
 ```
 

--- a/ordered_model/__init__.py
+++ b/ordered_model/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "ordered_model.apps.OrderedModelConfig"

--- a/ordered_model/apps.py
+++ b/ordered_model/apps.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig
+
+
+class OrderedModelConfig(AppConfig):
+    name = "ordered_model"
+    label = "ordered_model"
+
+    def ready(self):
+        # This import has side effects
+        # noinspection PyUnresolvedReferences
+        from .signals import on_ordered_model_delete

--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -194,6 +194,10 @@ class OrderedModelBase(models.Model):
         self._original_wrt_map = self._wrt_map()
 
     def delete(self, *args, extra_update=None, **kwargs):
+        # Flag re-ordering performed so that post_delete signal
+        # does not duplicate the re-ordering. See signals.py
+        self._was_deleted_via_delete_method = True
+
         qs = self.get_ordering_queryset()
         extra_update = {} if extra_update is None else extra_update
         qs.above_instance(self).decrease_order(**extra_update)

--- a/ordered_model/signals.py
+++ b/ordered_model/signals.py
@@ -7,7 +7,8 @@ from django.db.models import F
 @receiver(post_delete, dispatch_uid="on_ordered_model_delete")
 def on_ordered_model_delete(sender, instance, **kwargs):
     """
-    This signal makes sure that when an OrderedModelBase is deleted via cascade database deletes.
+    This signal makes sure that when an OrderedModelBase is deleted via cascade database deletes, the models
+    keep order.
     """
 
     """

--- a/ordered_model/signals.py
+++ b/ordered_model/signals.py
@@ -1,0 +1,29 @@
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+from ordered_model.models import OrderedModelBase
+from django.db.models import F
+
+
+@receiver(post_delete, dispatch_uid="on_ordered_model_delete")
+def on_ordered_model_delete(sender, instance, **kwargs):
+    """
+    This signal makes sure that when an OrderedModelBase is deleted via cascade database deletes.
+    """
+
+    """
+    We're only interested in subclasses of OrderedModelBase.
+    We want to be able to support 'extra_kwargs' on the delete()
+    method, which we can't do if we do all our work in the signal. We add a property to signal whether or not
+    the model's .delete() method was called, because if so - we don't need to do any more work.
+    """
+    if not issubclass(sender, OrderedModelBase):
+        return
+    if getattr(instance, "_was_deleted_via_delete_method", False):
+        return
+
+    extra_update = kwargs.get("extra_update", None)
+
+    # Copy of upshuffle logic from OrderedModelBase.delete
+    qs = instance.get_ordering_queryset()
+    extra_update = {} if extra_update is None else extra_update
+    qs.above_instance(instance).decrease_order(**extra_update)

--- a/tests/models.py
+++ b/tests/models.py
@@ -126,3 +126,11 @@ class ItemGroup(models.Model):
 class GroupedItem(OrderedModel):
     group = models.ForeignKey(ItemGroup, on_delete=models.CASCADE, related_name="items")
     order_with_respect_to = "group__user"
+
+
+class CascadedParentModel(models.Model):
+    pass
+
+
+class CascadedOrderedModel(OrderedModel):
+    parent = models.ForeignKey(to=CascadedParentModel, on_delete=models.CASCADE)


### PR DESCRIPTION
Fixes #182 

I've made a signal that's only activated when the model's `delete()` is not called, so we can support the update_kwargs from previously, but still keep order when we have cascaded deletes.

I've added a test that fails without the signal and passes with.