### PR TITLE
Fix support for Proxy model registrations with inline admins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,7 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Ignore static content for our test app
+tests/migrations
+tests/staticfiles

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Unreleased
 - Fix `OrderedTabularInline` for models with custom primary key field (#233)
 - Add management command `reorder_model` that can re-order most models with a broken ordering
 - Fix handling of keyword arguments passed to  `bulk_create` by Django 3 (#235)
+- Fix inline admin support for Proxy Models by adding parent model to url name (#242)
 
 3.4.1 - 2020-05-11
 ------------------

--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -213,7 +213,10 @@ class OrderedInlineMixin(BaseOrderedModelAdmin):
         fields = [
             str(value.pk)
             for value in order_with_respect_to.values()
-            if value.__class__ is self.parent_model
+            if (
+                type(value) == self.parent_model
+                or issubclass(self.parent_model, type(value))
+            )
             and value is not None
             and value.pk is not None
         ]

--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -146,7 +146,7 @@ class OrderedInlineModelAdminMixin:
         urls = super().get_urls()
         for inline in self.inlines:
             if issubclass(inline, OrderedInlineMixin):
-                urls = inline(self, self.admin_site).get_urls() + urls
+                urls = inline(self.model, self.admin_site).get_urls() + urls
         return urls
 
 

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from ordered_model.admin import (
     OrderedModelAdmin,
     OrderedTabularInline,
+    OrderedStackedInline,
     OrderedInlineModelAdminMixin,
 )
 
@@ -10,26 +11,45 @@ from .models import (
     Item,
     PizzaToppingsThroughModel,
     Pizza,
+    PizzaProxy,
+    Topping,
     CustomPKGroupItem,
     CustomPKGroup,
 )
 
-
+# README example for OrderedModelAdmin
 class ItemAdmin(OrderedModelAdmin):
     list_display = ("name", "move_up_down_links")
 
 
+# README example for TabularInline
 class PizzaToppingTabularInline(OrderedTabularInline):
     model = PizzaToppingsThroughModel
-    fields = ("order", "move_up_down_links")
+    fields = ("topping", "order", "move_up_down_links")
     readonly_fields = ("order", "move_up_down_links")
     ordering = ("order",)
+    extra = 1
 
 
 class PizzaAdmin(OrderedInlineModelAdminMixin, admin.ModelAdmin):
     model = Pizza
     list_display = ("name",)
     inlines = (PizzaToppingTabularInline,)
+
+
+# README example for StackedInline
+class PizzaToppingStackedInline(OrderedStackedInline):
+    model = PizzaToppingsThroughModel
+    fields = ("topping", "order", "move_up_down_links")
+    readonly_fields = ("order", "move_up_down_links")
+    ordering = ("order",)
+    extra = 1
+
+
+class PizzaProxyAdmin(OrderedInlineModelAdminMixin, admin.ModelAdmin):
+    model = PizzaProxy
+    list_display = ("name",)
+    inlines = (PizzaToppingStackedInline,)
 
 
 class CustomPKGroupItemInline(OrderedTabularInline):
@@ -45,4 +65,6 @@ class CustomPKGroupAdmin(OrderedInlineModelAdminMixin, admin.ModelAdmin):
 
 admin.site.register(Item, ItemAdmin)
 admin.site.register(Pizza, PizzaAdmin)
+admin.site.register(PizzaProxy, PizzaProxyAdmin)
+admin.site.register(Topping)
 admin.site.register(CustomPKGroup, CustomPKGroupAdmin)

--- a/tests/models.py
+++ b/tests/models.py
@@ -54,10 +54,16 @@ class CustomOrderFieldModel(OrderedModelBase):
 class Topping(models.Model):
     name = models.CharField(max_length=100)
 
+    def __str__(self):
+        return self.name
+
 
 class Pizza(models.Model):
     name = models.CharField(max_length=100)
     toppings = models.ManyToManyField(Topping, through="PizzaToppingsThroughModel")
+
+    def __str__(self):
+        return self.name
 
 
 class PizzaToppingsThroughModel(OrderedModel):
@@ -69,9 +75,16 @@ class PizzaToppingsThroughModel(OrderedModel):
         ordering = ("pizza", "order")
 
 
+# Admin only allows each model class to be registered once. However you can register a proxy class,
+# and (for presentation purposes only) rename it to match the existing in Admin
+class PizzaProxy(Pizza):
+    class Meta:
+        proxy = True
+        verbose_name = "Pizza"
+        verbose_name_plural = "Pizzas"
+
+
 # test many-one where the item has custom PK
-
-
 class CustomPKGroup(models.Model):
     name = models.CharField(max_length=100)
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,5 @@
 import django
+import os
 
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "db.sqlite3"}}
 ROOT_URLCONF = "tests.urls"
@@ -7,12 +8,13 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.messages",
+    "django.contrib.staticfiles",
     "django.contrib.sessions",
     "ordered_model",
     "tests",
 ]
 SECRET_KEY = "topsecret"
-
+DEBUG = True
 MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -34,3 +36,5 @@ TEMPLATES = [
         },
     }
 ]
+STATIC_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "staticfiles")
+STATIC_URL = "/static/"

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,6 @@
 import django
 
-DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "testdb"}}
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "db.sqlite3"}}
 ROOT_URLCONF = "tests.urls"
 INSTALLED_APPS = [
     "django.contrib.admin",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -576,14 +576,33 @@ class OrderedModelAdminTest(TestCase):
         self.assertEqual(Item.objects.get(name="item3").order, 1)
 
     def test_move_up_down_links_ordered_inline(self):
+        # model list
         res = self.client.get("/admin/tests/pizza/")
-        self.assertEqual(res.status_code, 200)
+        self.assertContains(
+            res, text="/admin/tests/pizza/{}/change/".format(self.pizza.id)
+        )
+
+        # model page including inlines
+        res = self.client.get("/admin/tests/pizza/{}/change/".format(self.pizza.id))
+        self.assertContains(
+            res,
+            text='<a href="/admin/tests/pizza/{}/pizzatoppingsthroughmodel/{}/move-up/">'.format(
+                self.pizza.id, self.pizza_to_ham.id
+            ),
+        )
+        self.assertContains(
+            res,
+            text='<a href="/admin/tests/pizza/{}/pizzatoppingsthroughmodel/{}/move-up/">'.format(
+                self.pizza.id, self.pizza_to_pineapple.id
+            ),
+        )
+
+        # click the move-up link
         self.assertEqual(self.pizza_to_ham.order, 0)
         self.assertEqual(self.pizza_to_pineapple.order, 1)
-
         res = self.client.get(
             "/admin/tests/pizza/{}/pizzatoppingsthroughmodel/{}/move-up/".format(
-                self.pizza.id, self.pineapple.id
+                self.pizza.id, self.pizza_to_pineapple.id
             ),
             follow=True,
         )
@@ -592,6 +611,22 @@ class OrderedModelAdminTest(TestCase):
         self.assertEqual(self.pizza_to_ham.order, 1)
         self.assertEqual(self.pizza_to_pineapple.order, 0)
         self.assertEqual(res.status_code, 200)
+
+    def test_move_up_down_proxy_stacked_inline(self):
+        res = self.client.get("/admin/tests/pizzaproxy/")
+        self.assertContains(
+            res, text="/admin/tests/pizzaproxy/{}/change/".format(self.pizza.id)
+        )
+
+        res = self.client.get(
+            "/admin/tests/pizzaproxy/{}/change/".format(self.pizza.id)
+        )
+        self.assertContains(
+            res,
+            text='<a href="/admin/tests/pizzaproxy/{}/pizzatoppingsthroughmodel/{}/move-up/">'.format(
+                self.pizza.id, self.pizza_to_ham.id
+            ),
+        )
 
 
 class OrderWithRespectToTestsManyToMany(TestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -997,13 +997,11 @@ class OrderedModelAdminWithCustomPKInlineTest(TestCase):
         # Check move up/down links
         self.assertContains(
             res,
-            text='<a href="/admin/tests/custompkgroup/1/custompkgroupitem/g1%20i1/move-up/"><img src="ordered_model/arrow-up.gif"></a>',
-            html=True,
+            text='<a href="/admin/tests/custompkgroup/1/custompkgroupitem/g1%20i1/move-up/">',
         )
         self.assertContains(
             res,
-            text='<a href="/admin/tests/custompkgroup/1/custompkgroupitem/g1%20i1/move-down/"><img src="ordered_model/arrow-down.gif"></a>',
-            html=True,
+            text='<a href="/admin/tests/custompkgroup/1/custompkgroupitem/g1%20i1/move-down/">',
         )
 
 


### PR DESCRIPTION
This is a failing test to show the issue in #242, once fixed it will add test coverage of `OrderedStackedInline`.
