### PR TITLE
add DragDropOrderedModelAdmin

### DIFF
--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -4,6 +4,7 @@ from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.encoding import escape_uri_path, iri_to_uri
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from django.template.loader import render_to_string
 from django.contrib import admin
@@ -258,3 +259,80 @@ class OrderedTabularInline(OrderedInlineMixin, admin.TabularInline):
 
 class OrderedStackedInline(OrderedInlineMixin, admin.StackedInline):
     pass
+
+
+class DragDropOrderedModelAdmin(BaseOrderedModelAdmin, admin.ModelAdmin):
+    def get_urls(self):
+        from django.urls import path
+
+        def wrap(view):
+            def wrapper(*args, **kwargs):
+                return self.admin_site.admin_view(view)(*args, **kwargs)
+
+            wrapper.model_admin = self
+            return update_wrapper(wrapper, view)
+
+        return [
+            path(
+                "<path:object_id>/move-above/<path:other_object_id>/",
+                wrap(self.move_above_view),
+                name="{app}_{model}_order_above".format(**self._get_model_info()),
+            )
+        ] + super().get_urls()
+
+    def move_above_view(self, request, object_id, other_object_id):
+        obj = get_object_or_404(self.model, pk=unquote(object_id))
+        other_obj = get_object_or_404(self.model, pk=unquote(other_object_id))
+        obj.above(other_obj)
+        # go back 3 levels (to get from /pk/move-above/other-pk back to the changelist)
+        return HttpResponseRedirect("../../../")
+
+    def make_draggable(self, obj):
+        model_info = self._get_model_info()
+        url = reverse(
+            "{admin_name}:{app}_{model}_order_above".format(
+                admin_name=self.admin_site.name, **model_info
+            ),
+            args=[-1, 0],  # placeholder pks, will be replaced in js
+        )
+        return mark_safe(
+            """
+        <div class="pk-holder" data-pk="%s"></div> <!-- render the pk into each row -->
+        <style>[draggable=true] { -khtml-user-drag: element; }</style>  <!-- fix for dragging in safari -->
+        <script>
+            window.__draggedObjPk = null;
+            django.jQuery(function () {
+                const $ = django.jQuery;
+                if (!window.__listSortableSemaphore) {  // make sure this part only runs once
+                    window.__move_to_url = '%s'; // this is the url including the placeholder pks
+                    $('#result_list > tbody > tr').each(function(idx, tr) {
+                        const $tr = $(tr);
+                        $tr.attr('draggable', 'true');
+                        const pk = $tr.find('.pk-holder').attr('data-pk');
+                        $tr.attr('data-pk', pk);
+                        $tr.on('dragstart', function (event) {
+                            event.originalEvent.dataTransfer.setData('text/plain', null);  // make draggable work in firefox
+                            window.__draggedObjPk = $(this).attr('data-pk');
+                        });
+                        $tr.on('dragover', false); // make it droppable
+                        $tr.on('drop', function (event) {
+                            event.preventDefault();  // prevent firefox from opening the dataTransfer data
+                            const otherPk = $(this).attr('data-pk');
+                            console.log(window.__draggedObjPk, 'dropped on', otherPk);
+                            const url = window.__move_to_url
+                                .replace('\/0\/', '/' + otherPk + '/')
+                                .replace('\/-1\/', '/' + window.__draggedObjPk + '/');
+                            console.log('redirecting', url);
+                            window.location = url;
+                        });
+                    });
+                    window.__listSortableSemaphore = true;
+                }
+            });
+        </script>
+        """
+            % (obj.pk, url)
+        )
+
+    make_draggable.allow_tags = True
+    make_draggable.short_description = ""

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 
 from ordered_model.admin import (
     OrderedModelAdmin,
+    DragDropOrderedModelAdmin,
     OrderedTabularInline,
     OrderedStackedInline,
     OrderedInlineModelAdminMixin,
@@ -9,6 +10,7 @@ from ordered_model.admin import (
 
 from .models import (
     Item,
+    ItemProxy,
     PizzaToppingsThroughModel,
     Pizza,
     PizzaProxy,
@@ -63,7 +65,13 @@ class CustomPKGroupAdmin(OrderedInlineModelAdminMixin, admin.ModelAdmin):
     inlines = (CustomPKGroupItemInline,)
 
 
+class DragDropItemAdmin(DragDropOrderedModelAdmin):
+    model = ItemProxy
+    list_display = ("name", "pk", "make_draggable")
+
+
 admin.site.register(Item, ItemAdmin)
+admin.site.register(ItemProxy, DragDropItemAdmin)
 admin.site.register(Pizza, PizzaAdmin)
 admin.site.register(PizzaProxy, PizzaProxyAdmin)
 admin.site.register(Topping)

--- a/tests/models.py
+++ b/tests/models.py
@@ -84,6 +84,11 @@ class PizzaProxy(Pizza):
         verbose_name_plural = "Pizzas"
 
 
+class ItemProxy(Item):
+    class Meta:
+        proxy = True
+
+
 # test many-one where the item has custom PK
 class CustomPKGroup(models.Model):
     name = models.CharField(max_length=100)


### PR DESCRIPTION
This is the code from #35 as posted on https://gist.github.com/devsnd/38b9d4ff573a0611a87f10ab3042db45 with a couple of changes to work on master.

It could use a few features but essentially it works.
- indicating the drop target
- some sort of icon or row decoration to indicate it can be dragged
- tests and documentation
 
