### PR TITLE
Fix reorder when order_with_respect_to field value changed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Unreleased
 - Use bulk update method in `reorder_model` management command for performance (#273)
 - Add tox builder for python 3.10, use upstream DRF with upstream django
 - Emit a system Check failure if a subclass of `OrderedModelBase` fails to specify `Meta.ordering`
+- Updating fields within `order_with_respect_to` now adjusts ordering accordingly (#198)
 
 3.6 - 2022-05-30
 ----------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ Unreleased
 - Use bulk update method in `reorder_model` management command for performance (#273)
 - Add tox builder for python 3.10, use upstream DRF with upstream django
 - Emit a system Check failure if a subclass of `OrderedModelBase` fails to specify `Meta.ordering`
-- Updating fields within `order_with_respect_to` now adjusts ordering accordingly (#198)
+- Updating the value of fields within `order_with_respect_to` now adjusts ordering accordingly (#198)
 
 3.6 - 2022-05-30
 ----------

--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -209,10 +209,7 @@ class OrderedInlineMixin(BaseOrderedModelAdmin):
 
         # Find the fields which refer to the parent model of this inline, and
         # use one of them if they aren't None.
-        order_with_respect_to = (
-            obj._meta.default_manager._get_order_with_respect_to_filter_kwargs(obj)
-            or []
-        )
+        order_with_respect_to = obj._wrt_map() or []
         fields = [
             str(value.pk)
             for value in order_with_respect_to.values()

--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -84,11 +84,13 @@ class OrderedModelQuerySet(models.QuerySet):
         objs = list(objs)
         order_with_respect_to_mapping = {}
         for obj in objs:
-            key = obj._wrt_map()
+            key = frozenset(obj._wrt_map().items())
             if key in order_with_respect_to_mapping:
                 order_with_respect_to_mapping[key] += 1
             else:
-                order_with_respect_to_mapping[key] = self.filter(**key).get_next_order()
+                order_with_respect_to_mapping[key] = self.filter(
+                    **obj._wrt_map()
+                ).get_next_order()
             setattr(obj, order_field_name, order_with_respect_to_mapping[key])
         return super().bulk_create(objs, *args, **kwargs)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -285,6 +285,34 @@ class OrderWithRespectToTests(TestCase):
         )
 
 
+class OrderWithRespectToReorderTests(TestCase):
+    def setUp(self):
+        q1 = Question.objects.create()
+        self.u0 = TestUser.objects.create()
+        self.u1 = TestUser.objects.create()
+        self.u0_a1 = q1.answers.create(user=self.u0)
+        self.u0_a2 = q1.answers.create(user=self.u0)
+        self.u0_a3 = q1.answers.create(user=self.u0)
+        self.u1_a1 = q1.answers.create(user=self.u1)
+        self.u1_a2 = q1.answers.create(user=self.u1)
+        self.u1_a3 = q1.answers.create(user=self.u1)
+
+    def test_reorder_when_field_value_changed(self):
+        self.u0_a2.user = self.u1
+        self.u0_a2.save()
+        self.assertSequenceEqual(
+            Answer.objects.values_list("pk", "order"),
+            [
+                (self.u0_a1.pk, 0),
+                (self.u0_a3.pk, 2),
+                (self.u1_a1.pk, 0),
+                (self.u1_a2.pk, 1),
+                (self.u1_a3.pk, 2),
+                (self.u0_a2.pk, 3),
+            ],
+        )
+
+
 class CustomPKTest(TestCase):
     def setUp(self):
         self.item1 = CustomItem.objects.create(pkid=str(uuid.uuid4()), name="1")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -304,7 +304,7 @@ class OrderWithRespectToReorderTests(TestCase):
             Answer.objects.values_list("pk", "order"),
             [
                 (self.u0_a1.pk, 0),
-                (self.u0_a3.pk, 2),
+                (self.u0_a3.pk, 1),
                 (self.u1_a1.pk, 0),
                 (self.u1_a2.pk, 1),
                 (self.u1_a3.pk, 2),


### PR DESCRIPTION
New iteration of https://github.com/django-ordered-model/django-ordered-model/pull/199

Added some more checks to ensure values are persisted in the `original_order_with_respect_to_fks` cache. The cache property could maybe use a rename considering it isn't always for FK fields.

This resolves the issues with reordering after the value of one of the fields in `order_with_respect_to` is changed. In my experience, this was resulting in duplicate order values and broken functionality.