### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - Django 4.0 compatibility: Fix ChangeList constructor for Admin (#256)
+- Remove usage of `assertEquals` in tests (#255)
 
 
 3.4.3 - 2021-04-20

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1064,7 +1064,7 @@ class ReorderModelTestCase(TestCase):
             [0, 1, 2],
         )
 
-        self.assertEquals(
+        self.assertEqual(
             "changing order of tests.GroupedItem (3) from 1 to 2\n", out.getvalue()
         )
 
@@ -1111,6 +1111,6 @@ class ReorderModelTestCase(TestCase):
             ["1", "2", "4"], [i.answer for i in OpenQuestion.objects.all()]
         )
 
-        self.assertEquals(
+        self.assertEqual(
             "changing order of tests.OpenQuestion (4) from 3 to 2\n", out.getvalue()
         )


### PR DESCRIPTION
The deprecated aliases have been removed in python/cpython#28268