### PR TITLE
Fix re-order command for custom order field models

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ Unreleased
 - Django 4.0 compatibility: Fix ChangeList constructor for Admin (#256)
 - Remove usage of `assertEquals` in tests (#255)
 - Add admin screenshots to README
-- Fix reorder command for custom order field models
+- Fix reorder command for custom order field models (#257)
 
 
 3.4.3 - 2021-04-20

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Unreleased
 - Django 4.0 compatibility: Fix ChangeList constructor for Admin (#256)
 - Remove usage of `assertEquals` in tests (#255)
 - Add admin screenshots to README
+- Fix reorder command for custom order field models
 
 
 3.4.3 - 2021-04-20

--- a/ordered_model/management/commands/reorder_model.py
+++ b/ordered_model/management/commands/reorder_model.py
@@ -79,7 +79,10 @@ class Command(BaseCommand):
                 if self.verbosity:
                     self.stdout.write(
                         "changing order of {} ({}) from {} to {}".format(
-                            model._meta.label, obj.pk, getattr(obj, order_field_name), order
+                            model._meta.label,
+                            obj.pk,
+                            getattr(obj, order_field_name),
+                            order,
                         )
                     )
                 setattr(obj, order_field_name, order)

--- a/ordered_model/management/commands/reorder_model.py
+++ b/ordered_model/management/commands/reorder_model.py
@@ -79,7 +79,7 @@ class Command(BaseCommand):
                 if self.verbosity:
                     self.stdout.write(
                         "changing order of {} ({}) from {} to {}".format(
-                            model._meta.label, obj.pk, obj.order, order
+                            model._meta.label, obj.pk, getattr(obj, order_field_name), order
                         )
                     )
                 setattr(obj, order_field_name, order)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1079,11 +1079,14 @@ class ReorderModelTestCase(TestCase):
             "reorder_model", "tests.CustomOrderFieldModel", verbosity=1, stdout=out
         )
         self.assertSequenceEqual(
-            CustomOrderFieldModel.objects.values_list("sort_order", flat=True).order_by("sort_order"),
+            CustomOrderFieldModel.objects.values_list("sort_order", flat=True).order_by(
+                "sort_order"
+            ),
             [0, 1, 2, 3, 4],
         )
         self.assertIn(
-            "changing order of tests.CustomOrderFieldModel (5) from 0 to 1", out.getvalue()
+            "changing order of tests.CustomOrderFieldModel (5) from 0 to 1",
+            out.getvalue(),
         )
 
     def test_shows_alternatives(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1074,8 +1074,16 @@ class ReorderModelTestCase(TestCase):
         when they overlap.
         """
         out = StringIO()
+        CustomOrderFieldModel.objects.create(name="5", sort_order=0)
         call_command(
             "reorder_model", "tests.CustomOrderFieldModel", verbosity=1, stdout=out
+        )
+        self.assertSequenceEqual(
+            CustomOrderFieldModel.objects.values_list("sort_order", flat=True).order_by("sort_order"),
+            [0, 1, 2, 3, 4],
+        )
+        self.assertIn(
+            "changing order of tests.CustomOrderFieldModel (5) from 0 to 1", out.getvalue()
         )
 
     def test_shows_alternatives(self):


### PR DESCRIPTION
Fix `AttributeError` error raised in reorder command when re-ordering models with custom order field.