### PR TITLE
Move setting the value of the order field to a separate method

### DIFF
--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -192,11 +192,17 @@ class OrderedModelBase(models.Model):
         """
         return self.get_ordering_queryset().above_instance(self).first()
 
-    def save(self, *args, **kwargs):
+    def set_ordered_field(self):
+        """
+        Set the value of the ordered field if it isnt set.
+        """
         order_field_name = self.order_field_name
         if getattr(self, order_field_name) is None:
             order = self.get_ordering_queryset().get_next_order()
             setattr(self, order_field_name, order)
+
+    def save(self, *args, **kwargs):
+        self.set_ordered_field()
         super().save(*args, **kwargs)
 
     def delete(self, *args, extra_update=None, **kwargs):


### PR DESCRIPTION
The purpose of this PR is to move the code snippet found on `OrderedModelBase.save` to its own method. This doesn't change the behavior of `.save`, but gives the `OrderedModelBase` class more flexibility for its child classes. This change is useful when a child class has another parent class whose `.save` method has more priority. 

Consider this:

```
class Animal(models.Model):
    def save(self, **kwargs):
          # do something important
          super().save(**kwargs)

class Dog(Animal, OrderedModel):
    def save(self, **kwargs):
          # save here will use Animal.save
          # but we also need to execute OrderedModel.save so the ordering will be set
          super().save(**kwargs)
```

with the changes in this PR, the following can be done

```
class Dog(Animal, OrderedModel):
    def save(self, **kwargs):
          self.set_ordered_field()     # sets the order field
          super().save(**kwargs)
```

