### PR TITLE
Use bulk update rather than save method for performance

### DIFF
--- a/ordered_model/management/commands/reorder_model.py
+++ b/ordered_model/management/commands/reorder_model.py
@@ -1,6 +1,6 @@
 from django.apps import apps
 from django.core.management import BaseCommand, CommandError
-from django.db import DatabaseError, transaction
+from django.db import transaction
 
 from ordered_model.models import OrderedModelBase
 
@@ -73,6 +73,7 @@ class Command(BaseCommand):
     def reorder_queryset(self, queryset):
         model = queryset.model
         order_field_name = model.order_field_name
+        bulk_update_list = []
 
         for order, obj in enumerate(queryset):
             if getattr(obj, order_field_name) != order:
@@ -86,4 +87,5 @@ class Command(BaseCommand):
                         )
                     )
                 setattr(obj, order_field_name, order)
-                obj.save()
+                bulk_update_list.append(obj)
+        model.objects.bulk_update(bulk_update_list, [order_field_name])

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 envlist =
-    py{35,36,37,38,39}-django22
-    py{36,37,38,39}-django30
-    py{36,37,38,39}-django31
-    py{36,37,38,39}-django32
-    py{38,39}-django40
-    py{38,39}-djangoupstream
-    py{38,39}-drfupstream
+    py{35,36,37,38,39,310}-django22
+    py{36,37,38,39,310}-django30
+    py{36,37,38,39,310}-django31
+    py{36,37,38,39,310}-django32
+    py{38,39,310}-django40
+    py{38,39,310}-djangoupstream
+    py{38,39,310}-drfupstream
     black
 
 [gh-actions]
@@ -17,6 +17,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv]
 deps =
@@ -31,7 +32,7 @@ deps =
     drfupstream: https://github.com/encode/django-rest-framework/archive/master.tar.gz
     django22: djangorestframework~=3.12.0
     django30,django31,django32: djangorestframework~=3.12.0
-    django40,djangoupstream: djangorestframework~=3.13.0
+    django40,djangoupstream: https://github.com/encode/django-rest-framework/archive/master.tar.gz
     coverage
 commands =
     coverage run {envbindir}/django-admin test --pythonpath=. --settings=tests.settings {posargs}


### PR DESCRIPTION
This is a separate PR from https://github.com/django-ordered-model/django-ordered-model/pull/272
Maybe it's easier to be reviewed:

- Use bulk update method in command for performance
- Add Python 3.10 in tox
- Fix error caused by DRF upstream