### PR TITLE
Add ordering to admin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ from models import Item
 
 class ItemAdmin(OrderedModelAdmin):
     list_display = ('name', 'move_up_down_links')
+    ordering = ('order',)
 
 admin.site.register(Item, ItemAdmin)
 ```


### PR DESCRIPTION
It took me a while before I realized why the ordering buttons in the admin example 'did not do anything'. After looking at database directly I realized they did work, it was just that the admin panel was not being ordered. I propose this small tweak to avoid others from struggling with this :)