### PR TITLE
Fix ordering in autocomplete select admin's widgets

### DIFF
--- a/ordered_model/admin.py
+++ b/ordered_model/admin.py
@@ -58,6 +58,15 @@ class BaseOrderedModelAdmin:
 
 
 class OrderedModelAdmin(BaseOrderedModelAdmin, admin.ModelAdmin):
+    def get_ordering(self, request):
+        ordering = list(super().get_ordering(request))
+
+        order_field_name = getattr(self.opts.model, "order_field_name", None)
+        if order_field_name and order_field_name not in ordering:
+            ordering.insert(0, order_field_name)
+
+        return ordering
+
     def get_urls(self):
         from django.urls import path
 

--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -27,7 +27,7 @@ class OrderedModelQuerySet(models.QuerySet):
         if order_with_respect_to is None:
             raise AssertionError(
                 (
-                    'ordered model admin "{0}" has not specified "order_with_respect_to"; note that this '
+                    'ordered admin "{0}" has not specified "order_with_respect_to"; note that this '
                     "should go in the model body, and is not to be confused with the Meta property of the same name, "
                     "which is independent Django functionality"
                 ).format(model)


### PR DESCRIPTION
I have noticed that the base model admin does not impose model ordering in autocomplete widgets. This is resolved by overriding `get_ordering` method.

Simple implementation proposed in this PR inserts the ordering field name (as defined in the admin's model) as the very first item to the `ordering` option, unless it's already present therein.