### PR TITLE
djangoupstream requires py310 or above

### DIFF
--- a/tests/admin.py
+++ b/tests/admin.py
@@ -17,6 +17,7 @@ from .models import (
     CustomPKGroup,
 )
 
+
 # README example for OrderedModelAdmin
 class ItemAdmin(OrderedModelAdmin):
     list_display = ("name", "move_up_down_links")

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,9 @@ envlist =
     py{36,37,38,39,310}-django31
     py{36,37,38,39,310}-django32
     py{38,39,310}-django40
-    py{38,39,310}-djangoupstream
-    py{38,39,310}-drfupstream
+    py{38,39,310}-django41
+    py{310}-djangoupstream
+    py{310}-drfupstream
     black
 
 [gh-actions]
@@ -26,6 +27,7 @@ deps =
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
     djangoupstream: https://github.com/django/django/archive/main.tar.gz
 
     drfupstream: Django~=3.2.0
@@ -33,6 +35,7 @@ deps =
     django22: djangorestframework~=3.12.0
     django30,django31,django32: djangorestframework~=3.12.0
     django40: djangorestframework~=3.13.0
+    django41: djangorestframework~=3.13.0
     djangoupstream: https://github.com/encode/django-rest-framework/archive/master.tar.gz
     coverage
 commands =


### PR DESCRIPTION
Fix build - black error and handle upstream django python >= 3.10