### PR TITLE
Add model warning if `OrderedModelBase` subclass `Meta` fails to declare `ordering` 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Unreleased
 
 - Use bulk update method in `reorder_model` management command for performance (#273)
 - Add tox builder for python 3.10, use upstream DRF with upstream django
+- Emit a system Check failure if a subclass of `OrderedModelBase` fails to specify `Meta.ordering`
 
 3.6 - 2022-05-30
 ----------

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -40,3 +40,4 @@ TEMPLATES = [
 REST_FRAMEWORK = {"DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.AllowAny"]}
 STATIC_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "staticfiles")
 STATIC_URL = "/static/"
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"


### PR DESCRIPTION
As discussed on #279 we can add a SystemCheck to identify if a model fails to declare or inherit an ordering field.
https://github.com/django-ordered-model/django-ordered-model/pull/new/add-model-warnings

This gives an error similar to the following:

    tests.UnorderedItemGeneratesWarning: (ordered_model.W001) OrderedModelBase subclass <class 'tests.models.UnorderedItemGeneratesWarning'> needs Meta.ordering specified.
	HINT: If you have overwritten Meta, try inheriting with Meta(OrderedModel.Meta).
