### PR TITLE
add `fields.OrderedManyToManyField` to order related models by through model Meta

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Unreleased
 - Fix `post_delete` signal triggered upshuffles to do a potentially expensive full reordering of the owrt group (#307)
 - Support passing custom `--batch_size` to `reorder_model` management command (#303)
 - Add tox builder for python 3.11, Django 4.1 and above
-
+- Add `ordered_model.fields.OrderedManyToManyField` which respects `Meta.ordering` when following ManyToMany related fields. (#277)
 
 3.7.4 - 2023-03-17
 ----------

--- a/ordered_model/fields.py
+++ b/ordered_model/fields.py
@@ -1,0 +1,48 @@
+from django.db.models.fields.related_descriptors import (
+    ManyToManyDescriptor,
+    create_forward_many_to_many_manager,
+)
+from django.utils.functional import cached_property
+from django.db import models
+
+# OrderedManyToManyField can be used in place of ManyToManyField and will
+# sort the returned data by the model Meta ordering when traversing child
+# objects
+
+
+def create_sorted_forward_many_to_many_manager(superclass, rel, reverse):
+    cls = create_forward_many_to_many_manager(superclass, rel, reverse)
+
+    class SortedManyRelatedManager(cls):
+        def get_queryset(self):
+            qs = super().get_queryset()
+            m = rel.through._meta
+            if m.ordering:
+                # import pdb; pdb.set_trace()
+                ors = [m.model_name + "__" + field for field in m.ordering]
+                qs = qs.order_by(*ors)
+            return qs
+
+    return SortedManyRelatedManager
+
+
+class SortedManyToManyDescriptor(ManyToManyDescriptor):
+    def __init__(self, field):
+        super().__init__(field.remote_field)
+
+    @cached_property
+    def related_manager_cls(self):
+        related_model = self.rel.related_model if self.reverse else self.rel.model
+
+        return create_sorted_forward_many_to_many_manager(
+            related_model._default_manager.__class__,
+            self.rel,
+            reverse=self.reverse,
+        )
+
+
+class OrderedManyToManyField(models.ManyToManyField):
+    def contribute_to_class(self, cls, name, **kwargs):
+        super().contribute_to_class(cls, name, **kwargs)
+        # print(f"contributed to {cls} {name} remote_field={self.remote_field}")
+        setattr(cls, self.name, SortedManyToManyDescriptor(self))

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 
 from ordered_model.models import OrderedModel, OrderedModelBase
+from ordered_model.fields import OrderedManyToManyField
 import uuid
 
 
@@ -146,3 +147,18 @@ class StateMachine(OrderedModel):
     name = models.CharField(max_length=32)
     flow = models.ForeignKey(Flow, on_delete=models.PROTECT, null=True, blank=True)
     order_with_respect_to = "flow"
+
+
+# Duplicate Pizza models using OrderedManyToManyField
+class PizzaOM2M(models.Model):
+    name = models.CharField(max_length=100)
+    toppings = OrderedManyToManyField(Topping, through="PizzaOM2MToppingsThroughModel")
+
+
+class PizzaOM2MToppingsThroughModel(OrderedModel):
+    pizza = models.ForeignKey(PizzaOM2M, on_delete=models.CASCADE)
+    topping = models.ForeignKey(Topping, on_delete=models.CASCADE)
+    order_with_respect_to = "pizza"
+
+    class Meta:
+        ordering = ("pizza", "order")


### PR DESCRIPTION
Assuming a 'through' model is provided to the field, it will be queried while constructing `QuerySet`s for related models and the through model `Meta.ordering` clauses will be applied.

Use in place of `fields.ManyToManyField`.

Fixes #277, although experimental and needs tests, at least to assess which versions it will work under.