### PR TITLE
WIP: Optimize OrderedModelBase._wrt_map() - reduce query count

### DIFF
--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -127,8 +127,11 @@ class OrderedModelBase(models.Model):
 
     def _wrt_map(self):
         d = {}
-        for a in self.get_order_with_respect_to():
-            d[a] = get_lookup_value(self, a)
+        for order_field_name in self.get_order_with_respect_to():
+            if not order_field_name.endswith("_id"):
+                order_field_name = order_field_name + "_id"
+            d[order_field_name] = get_lookup_value(self, order_field_name)
+
         return d
 
     @classmethod

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,37 @@
+# Query count helpers, copied from django source
+# Added here for compatibility (django<3.1)
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.test.utils import CaptureQueriesContext
+
+
+class _AssertNumQueriesContext(CaptureQueriesContext):
+    def __init__(self, test_case, num, connection):
+        self.test_case = test_case
+        self.num = num
+        super().__init__(connection)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        if exc_type is not None:
+            return
+        executed = len(self)
+        self.test_case.assertEqual(
+            executed, self.num,
+            "%d queries executed, %d expected\nCaptured queries were:\n%s" % (
+                executed, self.num,
+                '\n'.join(
+                    '%d. %s' % (i, query['sql']) for i, query in enumerate(self.captured_queries, start=1)
+                )
+            )
+        )
+
+
+def assertNumQueries(self, num, func=None, *args, using=DEFAULT_DB_ALIAS, **kwargs):
+    conn = connections[using]
+
+    context = _AssertNumQueriesContext(self, num, conn)
+    if func is None:
+        return context
+
+    with context:
+        func(*args, **kwargs)


### PR DESCRIPTION
I've recently updated the version of django-ordered-model from one of my projects, and noticed that the change from `3.6` to `3.7` caused one of my SQL query count tests to fail. After some investigation, I found that there were additional (unnecessary) query caused by `wrt_map()` when initializing the instance. Specifically, one (1) SQL query was added for every field in `order_with_respect_to`

I found that `wrt_map` gets the actual related object from the database. And the `.save()` method [compares the value](https://github.com/django-ordered-model/django-ordered-model/blob/master/ordered_model/models.py#L182) from `_original_wrt_map`. 

Now, I figured, that instead of actually comparing the objects, we could achieve the same result by comparing the `_id` of the fields instead. More in this below.

**To visualize the problem**
Let's use the [Answer model](https://github.com/django-ordered-model/django-ordered-model/blob/master/ordered_model/models.py#L182) from our tests/models.py

Fetching an object from the database yieds:
```
answer = Answer.objects.get()    
# 3 sql queries!
# 1. SELECT "tests_answer"."id", "tests_answer"."order", "tests_answer"."question_id", "tests_answer"."user_id" FROM "tests_answer" ORDER BY "tests_answer"."question_id" ASC, "tests_answer"."user_id" ASC, "tests_answer"."order" ASC LIMIT 1
# 2. SELECT "tests_question"."id" FROM "tests_question" WHERE "tests_question"."id" = 1 LIMIT 21
# 3. SELECT "tests_testuser"."id" FROM "tests_testuser" WHERE "tests_testuser"."id" = 1 LIMIT 21
```

this is caused by the invocation of `_wrt_map()` from OrderedModelBase.__init__ to define the `_original_wrt_map`. 

**Proposed Solution**

The changes I've introduced in this PR, uses the field `_id` instead of the related object when building the `wrt_map`. This way, the related object is not fetched from the database (if not yet set prior).

Caveat: This solution only works for `order_with_respect_to` fields that are actually `ForeignKeys`. As of writing, I have not yet tested it on reverse FK, ManyToMany, etc. I know my changes will not work for these. I'm hoping someone could contribute to solving the problem.

**Alternate (Temporary) Solution**

The easier solution here, and without code change, would be to hardcode `_id` when defining the `order_with_respect_to`. So instead of
```
    class Answer(models.Model):
        order_with_respect_to = ("question", "user")
```
we could define our model:
``````
    class Answer(models.Model):
        order_with_respect_to = ("question_id", "user_id")
```

This of course, requires that we update the documentation, and also assumes that the package user (developer) is aware of this problem, and would require them to update existing code. I would not suggest this as a long term solution.


