### PR TITLE
Fix `reorder_model` management command re-ordering with multiple `order_with_respect_to` values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Change log
 Unreleased
 ----------
 
+- Fix `reorder_model` management command re-ordering with multiple `order_with_respect_to` values
+
 3.7.2 - 2023-03-14
 ----------
 - Fix a performance regression (unnecessary queries) in the WRT change detection (#286)

--- a/ordered_model/management/commands/reorder_model.py
+++ b/ordered_model/management/commands/reorder_model.py
@@ -5,17 +5,6 @@ from django.db import transaction
 from ordered_model.models import OrderedModelBase
 
 
-def get_order_with_respect_to(model):
-    if not model.order_with_respect_to:
-        return None
-    if isinstance(model.order_with_respect_to, str):
-        return model.order_with_respect_to
-    assert (
-        len(model.order_with_respect_to) <= 1
-    ), "re-ordering with more than 1 fields in order_with_respect_to is not supported"
-    return model.order_with_respect_to[0]
-
-
 class Command(BaseCommand):
     help = "Re-do the ordering of a certain Model"
 
@@ -54,17 +43,18 @@ class Command(BaseCommand):
             self.reorder(model)
 
     def reorder(self, model):
-        if model.order_with_respect_to:
-            order_with_respect_to = get_order_with_respect_to(model)
-            rel_kwargs = {"{}__isnull".format(order_with_respect_to): False}
+        owrt = model.get_order_with_respect_to()
+        if owrt:
+            rel_kwargs = dict([("{}__isnull".format(k), False) for k in owrt])
             relation_to_list = (
-                model.objects.order_by(order_with_respect_to)
-                .values_list(order_with_respect_to, flat=True)
+                model.objects.order_by(*owrt)
+                .values_list(*owrt)
                 .filter(**rel_kwargs)
                 .distinct()
             )
             for relation_to in relation_to_list:
-                kwargs = {order_with_respect_to: relation_to}
+                kwargs = dict([(k, v) for k, v in zip(owrt, relation_to)])
+                # print('re-ordering: {}'.format(kwargs))
                 self.reorder_queryset(model.objects.filter(**kwargs))
         else:
             self.reorder_queryset(model.objects.all())


### PR DESCRIPTION
Closes #198 