### PR TITLE
relax OrderedModelManager check to a Warning if it returns OrderedModelQuerySet

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ Change log
 Unreleased
 ----------
 
+3.7.4 - 2023-03-17
+----------
+- Relax Check for `OrderedModelManager` to a `Warning`, if the manager returns the correct queryset (#290)
+
+
 3.7.3 - 2023-03-15
 ----------
 - Restrict signal handler 'senders' to subclasses of `OrderedModelBase` to avoid query count regression due to `Collector.can_fast_delete` logic in `models/deletion.py` (#288)

--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -358,14 +358,25 @@ class OrderedModelBase(models.Model):
                 )
             )
         if not issubclass(cls.objects.__class__, OrderedModelManager):
-            errors.append(
-                checks.Error(
-                    "OrderedModelBase subclass has a ModelManager that does not inherit from OrderedModelManager.",
-                    obj=str(cls.__qualname__),
-                    id="ordered_model.E003",
+            # Not using our Manager. This is an Error if the queryset is also wrong, or
+            # a Warning if our own QuerySet is returned.
+            if issubclass(cls.objects.none().__class__, OrderedModelQuerySet):
+                errors.append(
+                    checks.Warning(
+                        "OrderedModelBase subclass has a ModelManager that does not inherit from OrderedModelManager. This is not ideal but will work.",
+                        obj=str(cls.__qualname__),
+                        id="ordered_model.W003",
+                    )
                 )
-            )
-        if not issubclass(cls.objects.none().__class__, OrderedModelQuerySet):
+            else:
+                errors.append(
+                    checks.Error(
+                        "OrderedModelBase subclass has a ModelManager that does not inherit from OrderedModelManager.",
+                        obj=str(cls.__qualname__),
+                        id="ordered_model.E003",
+                    )
+                )
+        elif not issubclass(cls.objects.none().__class__, OrderedModelQuerySet):
             errors.append(
                 checks.Error(
                     "OrderedModelBase subclass ModelManager did not return a QuerySet inheriting from OrderedModelQuerySet.",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     name="django-ordered-model",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="3.7.3",
+    version="3.7.4",
     description="Allows Django models to be ordered and provides a simple admin interface for reordering them.",
     author="Ben Firshman",
     author_email="ben@firshman.co.uk",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1376,7 +1376,7 @@ class ChecksTest(SimpleTestCase):
         )
 
     def test_bad_manager(self):
-        class BadModelManager(models.Manager.from_queryset(OrderedModelQuerySet)):
+        class BadModelManager(models.Manager.from_queryset(models.QuerySet)):
             pass
 
         class TestModel(OrderedModel):
@@ -1389,6 +1389,21 @@ class ChecksTest(SimpleTestCase):
                     msg="OrderedModelBase subclass has a ModelManager that does not inherit from OrderedModelManager.",
                     obj="ChecksTest.test_bad_manager.<locals>.TestModel",
                     id="ordered_model.E003",
+                )
+            ],
+        )
+
+    def test_builtin_manager_to_queryset(self):
+        class TestModel(OrderedModel):
+            objects = OrderedModelQuerySet.as_manager()
+
+        self.assertEqual(
+            checks.run_checks(app_configs=self.apps.get_app_configs()),
+            [
+                checks.Warning(
+                    msg="OrderedModelBase subclass has a ModelManager that does not inherit from OrderedModelManager. This is not ideal but will work.",
+                    obj="ChecksTest.test_builtin_manager_to_queryset.<locals>.TestModel",
+                    id="ordered_model.W003",
                 )
             ],
         )


### PR DESCRIPTION
This is to allow some leeway for e.g. `django-admin-index` users that have a working, but not by the book inherited arrangement.
