### PR TITLE
Add `--batch_size` arg to management command (for bulk_update)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change log
 Unreleased
 ----------
 - Fix `post_delete` signal triggered upshuffles to do a potentially expensive full reordering of the owrt group (#307)
+- Support passing custom `--batch_size` to `reorder_model` management command (#303)
 
 
 3.7.4 - 2023-03-17

--- a/ordered_model/management/commands/reorder_model.py
+++ b/ordered_model/management/commands/reorder_model.py
@@ -10,6 +10,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("model_name", type=str, nargs="*")
+        parser.add_argument("--batch_size", type=int, nargs=1, default=1000)
 
     def handle(self, *args, **options):
         """
@@ -17,6 +18,8 @@ class Command(BaseCommand):
         try re-ordering to a working state.
         """
         self.verbosity = options["verbosity"]
+        self.batch_size = options["batch_size"]
+
         orderedmodels = [
             m._meta.label for m in apps.get_models() if issubclass(m, OrderedModelBase)
         ]
@@ -78,4 +81,7 @@ class Command(BaseCommand):
                     )
                 setattr(obj, order_field_name, order)
                 bulk_update_list.append(obj)
-        model.objects.bulk_update(bulk_update_list, [order_field_name])
+
+        model.objects.bulk_update(
+            bulk_update_list, [order_field_name], batch_size=self.batch_size
+        )

--- a/ordered_model/management/commands/reorder_model.py
+++ b/ordered_model/management/commands/reorder_model.py
@@ -10,7 +10,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("model_name", type=str, nargs="*")
-        parser.add_argument("--batch_size", type=int, nargs=1, default=1000)
+        parser.add_argument("--batch_size", type=int, nargs=1, default=None)
 
     def handle(self, *args, **options):
         """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1245,6 +1245,42 @@ class ReorderModelTestCase(TestCase):
             "changing order of tests.OpenQuestion (4) from 3 to 2\n", out.getvalue()
         )
 
+    def test_reorder_with_custom_batch_size(self):
+        """
+        Test that 'reorder_model' can be called with a valid `batch_size` argument.
+        """
+        OpenQuestion.objects.create(order=0)
+        OpenQuestion.objects.create(order=0)
+        out = StringIO()
+        call_command(
+            "reorder_model", "tests.OpenQuestion", verbosity=1, stdout=out, batch_size=2
+        )
+
+        self.assertSequenceEqual(
+            OpenQuestion.objects.values_list("order", flat=True).order_by("order"),
+            [0, 1],
+        )
+        self.assertIn(
+            "changing order of tests.OpenQuestion (2) from 0 to 1", out.getvalue()
+        )
+
+    def test_reorder_with_invalid_custom_batch_size(self):
+        """
+        Test that 'reorder_model' raises a TypeError if a non-int value is passed
+        as the `batch_size` argument.
+        """
+        OpenQuestion.objects.create(order=0)
+        OpenQuestion.objects.create(order=0)
+
+        with self.assertRaises(TypeError):
+            call_command(
+                "reorder_model",
+                "tests.OpenQuestion",
+                verbosity=1,
+                stdout=StringIO(),
+                batch_size="2",
+            )
+
 
 class DRFTestCase(APITestCase):
     fixtures = ["test_items.json"]


### PR DESCRIPTION
The docs for `bulk_update` say:

> If updating a large number of columns in a large number of rows, the SQL generated can be very large. Avoid this by specifying a suitable batch_size.

If this SQL is too large, it can fail. We of course aren't modifying a large number of columns, so this may not be a practical concern, but we don't know how many rows will need to be updated, so it seems sensible to allow callers to provide a different `batch_size` if necessary.

This PR adds a `--batch-size` option to the management command that defaults to 1000.

I added tests that cover passing the `batch_size` argument, but I'm not quite sure how to check how many queries were executed (or if it's necessary to do so).