### PR TITLE
Return super().delete() in OrderedModel#delete

### DIFF
--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -230,7 +230,7 @@ class OrderedModelBase(models.Model):
         qs = self.get_ordering_queryset()
         extra_update = {} if extra_update is None else extra_update
         qs.above_instance(self).decrease_order(**extra_update)
-        super().delete(*args, **kwargs)
+        return super().delete(*args, **kwargs)
 
     def swap(self, replacement):
         """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -151,7 +151,10 @@ class ModelTestCase(TestCase):
         self.assertNames(["1", "2", "3", "4"])
 
     def test_delete(self):
-        Item.objects.get(pk=2).delete()
+        deleted = Item.objects.get(pk=2).delete()
+        # the default return value of delete is (num_deleted, deleted_count_per_model)
+        # https://github.com/django/django/blob/main/django/db/models/deletion.py#L522
+        self.assertEqual(deleted, (1, {"tests.Item": 1}))
         self.assertNames(["1", "3", "4"])
         Item.objects.get(pk=3).up()
         self.assertNames(["3", "1", "4"])


### PR DESCRIPTION
This makes `django-ordered-model` play nicely with other libraries that rely on the return value of model#delete such as `django-safedelete`.

Right now, when there's a model that subclasses `SafeDeleteModel` and `OrderedModel`, we have to override `delete()` and duplicate the logic in `OrderedModel#delete` because the queryset in `django-safedelete` relies on the return value of `model#delete`.