### PR TITLE
Enable the request context processor during tests

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -33,6 +33,7 @@ TEMPLATES = [
             "context_processors": [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "django.template.context_processors.request",
             ]
         },
     }


### PR DESCRIPTION
Without this recent versions of Django emit a warning during testing.