### PR TITLE
Fix RemovedInDjango41Warning on `default_app_config`

### DIFF
--- a/ordered_model/__init__.py
+++ b/ordered_model/__init__.py
@@ -1,4 +1,4 @@
 import django
 
 if django.VERSION < (3, 2):
-  default_app_config = "ordered_model.apps.OrderedModelConfig"
+    default_app_config = "ordered_model.apps.OrderedModelConfig"

--- a/ordered_model/__init__.py
+++ b/ordered_model/__init__.py
@@ -1,1 +1,4 @@
-default_app_config = "ordered_model.apps.OrderedModelConfig"
+import django
+
+if django.VERSION < (3, 2):
+  default_app_config = "ordered_model.apps.OrderedModelConfig"


### PR DESCRIPTION
[Since Django 3.2](https://code.djangoproject.com/ticket/31180
), the property has been deprecated as it is automatically detected by Django. Currently when `django-ordered-model` is loaded into a Django 3.2+ project, it throws deprecation warnings

The pattern in this PR can be found in other libraries that need to support wide ranges of Django versions:
https://github.com/revsys/django-health-check/blob/master/health_check/db/__init__.py
