### PR TITLE
Allow using `order_with_respect_to` with `_id` suffix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
 
     steps:
     - uses: actions/checkout@v1

--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -130,7 +130,11 @@ class OrderedModelBase(models.Model):
         d = {}
         for order_wrt_name in self.get_order_with_respect_to():
             # we know order_wrt_name is a ForeignKey, so use a cheaper _id lookup
-            field_path = order_wrt_name + "_id"
+            field_path = (
+                order_wrt_name + "_id"
+                if not order_wrt_name.endswith("_id")
+                else order_wrt_name
+            )
             d[order_wrt_name] = get_lookup_value(self, field_path)
         return d
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -22,7 +22,7 @@ class Answer(OrderedModel):
         Question, on_delete=models.CASCADE, related_name="answers"
     )
     user = models.ForeignKey(TestUser, on_delete=models.CASCADE, related_name="answers")
-    order_with_respect_to = ("question", "user")
+    order_with_respect_to = ("question", "user_id")
 
     class Meta:
         ordering = ("question", "user", "order")

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
 envlist =
-    py{35,36,37,38,39,310}-django22
-    py{36,37,38,39,310}-django30
-    py{36,37,38,39,310}-django31
-    py{36,37,38,39,310}-django32
-    py{38,39,310}-django40
-    py{38,39,310}-django41
-    py{310}-djangoupstream
-    py{310}-drfupstream
+    py{35,36,37,38,39}-django22
+    py{36,37,38,39,310,311}-django30
+    py{36,37,38,39,310,311}-django31
+    py{36,37,38,39,310,311}-django32
+    py{38,39,310,311}-django40
+    py{38,39,310,311}-django41
+    py{310,311}-djangoupstream
+    py{310,311}-drfupstream
     black
 
 [gh-actions]
@@ -19,6 +19,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 deps =


### PR DESCRIPTION
Allow users to declare `order_with_respect_to` as:
```Python
class Foo(OrderedModel):
  bar = models.ForeignKey(Bar, on_delete=models.CASCADE, related_name="foos")
  order_with_respect_to = ("bar_id")
```

Also added Python 3.11 in tox.ini