### PR TITLE
Do not change source object order when coping

### DIFF
--- a/ordered_model/models.py
+++ b/ordered_model/models.py
@@ -211,7 +211,8 @@ class OrderedModelBase(models.Model):
 
     def save(self, *args, **kwargs):
         order_field_name = self.order_field_name
-        wrt_changed = self._wrt_map() != self._original_wrt_map
+        adding = self.pk is None or self._state.adding
+        wrt_changed = not adding and self._wrt_map() != self._original_wrt_map
 
         if wrt_changed and getattr(self, order_field_name) is not None:
             # do delete-like upshuffle using original_wrt values!

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -173,6 +173,23 @@ class OrderWithRespectToTests(TestCase):
         with assertNumQueries(self, 1):
             Answer.objects.get(id=self.q1_a1.id)
 
+    def test_copy(self):
+        q3 = Question.objects.create()
+        old_q1_a1_pk = self.q1_a1.pk
+        self.q1_a1.pk = None
+        self.q1_a1.question = q3
+        self.q1_a1.save()
+        self.assertSequenceEqual(
+            Answer.objects.values_list("pk", "order"),
+            [
+                (old_q1_a1_pk, 0),
+                (self.q1_a2.pk, 1),
+                (self.q2_a1.pk, 0),
+                (self.q2_a2.pk, 1),
+                (self.q1_a1.pk, 0),
+            ],
+        )
+
     def test_saved_order(self):
         self.assertSequenceEqual(
             Answer.objects.values_list("pk", "order"),
@@ -296,6 +313,28 @@ class OrderWithRespectToTests(TestCase):
                 (self.q1_a2.pk, 1),
                 (self.q2_a2.pk, 0),
                 (self.q2_a1.pk, 1),
+            ],
+        )
+
+
+class OrderWithRespectToCustomPKTest(TestCase):
+    def setUp(self):
+        group = CustomPKGroup.objects.create(name="g1")
+        self.item = CustomPKGroupItem.objects.create(name="g1 i1", group=group)
+        CustomPKGroupItem.objects.create(name="g1 i2", group=group)
+
+    def test_copy(self):
+        group = CustomPKGroup.objects.create(name="g2")
+        self.item.name = "g2 i1"
+        self.item._state.adding = True
+        self.item.group = group
+        self.item.save()
+        self.assertSequenceEqual(
+            CustomPKGroupItem.objects.order_by("name").values_list("name", "order"),
+            [
+                ("g1 i1", 0),
+                ("g1 i2", 1),
+                ("g2 i1", 0),
             ],
         )
 


### PR DESCRIPTION
In case when `order_with_respect_to` used and [model instance copied by means of setting `model_object.pk = None`](https://docs.djangoproject.com/en/4.2/topics/db/queries/#copying-model-instances) with changed wrt value objects with the original wrt above got reordered.

Currently there are 2 possible workarounds:
* set `model_objects.order = None` but it leads to an extra db query to set `order`
* use `bulk_create`