### PR TITLE
Relax `order_with_respect_to` final element must be `ForeignKey` (#298)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Unreleased
 - Support passing custom `--batch_size` to `reorder_model` management command (#303)
 - Add tox builder for python 3.11, Django 4.1 and above
 - Add `ordered_model.fields.OrderedManyToManyField` which respects `Meta.ordering` when following ManyToMany related fields. (#277)
+- Relax check that `order_with_respect_to` entries final element must be a `ForeignKey` - it can be any `Field` instance (#298)
+
 
 3.7.4 - 2023-03-17
 ----------

--- a/tests/models.py
+++ b/tests/models.py
@@ -162,3 +162,25 @@ class PizzaOM2MToppingsThroughModel(OrderedModel):
 
     class Meta:
         ordering = ("pizza", "order")
+
+
+# issue 298
+class Training(models.Model):
+    pass
+
+
+class TrainingExercise(OrderedModel, models.Model):
+    WARMUP = 1
+    MAINPART = 2
+    ENDPART = 3
+    TrainingChoices = [
+        (WARMUP, "WarmUp"),
+        (MAINPART, "MainPart"),
+        (ENDPART, "EndPart"),
+    ]
+    training = models.ForeignKey(Training, on_delete=models.CASCADE)
+    stage = models.PositiveSmallIntegerField(choices=TrainingChoices)
+    order_with_respect_to = ("training", "stage")
+
+    class Meta:
+        ordering = ("training", "stage")

--- a/tox.ini
+++ b/tox.ini
@@ -38,9 +38,9 @@ deps =
     django40: djangorestframework~=3.13.0
     django41: djangorestframework~=3.13.0
     djangoupstream: https://github.com/encode/django-rest-framework/archive/master.tar.gz
-    coverage
 commands =
-    coverage run {envbindir}/django-admin test --pythonpath=. --settings=tests.settings {posargs}
+    {envbindir}/django-admin check --pythonpath=. --settings=tests.settings
+    {envbindir}/django-admin test --pythonpath=. --settings=tests.settings {posargs}
 
 [testenv:black]
 basepython = python3


### PR DESCRIPTION
Relax `order_with_respect_to` final element must be `ForeignKey` - it can be any `Field` instance (#298)

This required re-working the optimisation in c4630dca2bdafd6bac1bd2328081f524953872cf to handle OWRT paths ending on a non ForeignKey field.
Add tets covering using `PositiveSmallIntegerField` with choices specified.