### PR TITLE
add pip-trusted-host, due to TLSv1 deprecation certificate errors on py35

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,20 @@ jobs:
     strategy:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
-
+        include:
+          - pip-trusted-host: ''
+          # Relax security checks for Python 3.5 only. (https://github.com/actions/setup-python/issues/866)
+          - python-version: '3.5'
+            pip-trusted-host: 'pypi.python.org pypi.org files.pythonhosted.org'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+      env:
+        PIP_TRUSTED_HOST: ${{ matrix.pip-trusted-host }}
+        PIP_DISABLE_PIP_VERSION_CHECK: 1
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     py{36,37,38,39,310}-django32
     py{38,39,310}-django40
     py{38,39,310,311}-django41
+    py{38,39,310,311}-django42
     py{310,311}-djangoupstream
     py{310}-drfupstream
     black
@@ -29,14 +30,16 @@ deps =
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<4.3
     djangoupstream: https://github.com/django/django/archive/main.tar.gz
 
-    drfupstream: Django~=3.2.0
+    drfupstream: Django~=4.2.0
     drfupstream: https://github.com/encode/django-rest-framework/archive/master.tar.gz
     django22: djangorestframework~=3.12.0
     django30,django31,django32: djangorestframework~=3.12.0
     django40: djangorestframework~=3.13.0
     django41: djangorestframework~=3.13.0
+    django42: djangorestframework~=3.15.0
     djangoupstream: https://github.com/encode/django-rest-framework/archive/master.tar.gz
 commands =
     {envbindir}/django-admin check --pythonpath=. --settings=tests.settings


### PR DESCRIPTION
Relax security check as described in https://github.com/actions/setup-python/issues/866
